### PR TITLE
(wip) semantic aliases

### DIFF
--- a/lib/scheme.class.js
+++ b/lib/scheme.class.js
@@ -22,6 +22,17 @@ function reverseHex(hex) {
   return `${m[3]}${m[2]}${m[1]}`;
 }
 
+// all other keys are assumed to be base00 colors or aliases
+RESERVED_KEYS = [
+  "scheme",
+  "author",
+]
+
+const MAX_ALIAS_DEPTH = 10
+const HEXCOLOR = /^([0-9A-F]){6}$/i
+class AmbiguousAlias extends Error {}
+class AliasRecursionOverflow extends Error {}
+
 /**
  * Represents a Base16 scheme definition.
  */
@@ -41,9 +52,29 @@ class Scheme {
    * for use with Base16 mustache templates.
    */
   parseScheme (data) {
+    const resolveAliases = (key, data) => {
+      let maxdepth = MAX_ALIAS_DEPTH;
+
+      let alias = data[key];
+      while (maxdepth--) {
+        if (!data[alias]) { return };
+
+        if (HEXCOLOR.test(alias)) {
+          let err = `Alias '${alias}' is ambiguous (could also be a hexcolor) and not allowed.`
+          throw new AmbiguousAlias(err);
+        }
+
+        data[key] = data[alias]
+        alias = data[alias]
+      }
+
+      throw new AliasRecursionOverflow(`Key ${key} led to alias recursion overflow.`)
+    }
     const hexDefinitions = Object.keys(data).reduce((accumulator, key) => {
+      resolveAliases(key, data);
+
       // we're only interested in the hex bases at this point
-      if (!/^base/i.test(key)) return accumulator
+      if (RESERVED_KEYS.includes(key)) return accumulator;
 
       const hex = data[key]
         // strip leading # if present for 0.10.0 spec


### PR DESCRIPTION
First pass at implementation of proposal https://github.com/base16-project/base16/issues/11

My test case:

```yaml
scheme: "Nord"
author: "arcticicestudio"
# Nord Palette
nord0: "2E3440"
nord1: "3B4252"
nord2: "434C5E"
nord3: "4C566A"
nord4: "D8DEE9"
nord5: "E5E9F0"
nord6: "ECEFF4"
nord7: "8FBCBB"
nord8: "88C0D0"
nord9: "81A1C1"
nord10: "5E81AC"
nord11: "BF616A"
nord12: "D08770"
nord13: "EBCB8B"
nord14: "A3BE8C"
nord15: "B48EAD"
# Semantic colors
diff-added: nord14
diff-deleted: nord11
diff-changed: nord13
# Defaults for older templates
base00: nord0
base01: nord1
base02: nord2
base03: nord3
base04: nord4
base05: nord5
base06: nord6
base07: nord7
base08: nord11
base09: nord12
base0A: nord13
base0B: nord14
base0C: nord8
base0D: nord9
base0E: nord15
base0F: nord10

```

And then just playing around with an old template:

```css
/*
nord0 #{{nord0-hex}}
nord0 bgr #{{nord0-hex-bgr}}
nord1 #{{nord1-hex}}
nord2 #{{nord2-hex}}
*/

.hljs-deletion {
  color: #{{diff-deleted-hex}};
}
```