### PR TITLE
Add github action to notify codeowners when an issue is created

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,1 @@
+* @tinted-theming/builder-node

--- a/.github/workflows/auto-assign-issues.yml
+++ b/.github/workflows/auto-assign-issues.yml
@@ -1,0 +1,11 @@
+name: "Auto assignment for issues"
+
+on:
+  issues:
+    types: ["opened"]
+
+jobs:
+  auto-assign:
+    uses: "tinted-theming/home/.github/workflows/shared-auto-assign-issues.yml@main"
+    secrets:
+      token: ${{ secrets.BOT_ACCESS_TOKEN }}


### PR DESCRIPTION
Uses https://github.com/tinted-theming/home/blob/main/.github/workflows/shared-auto-assign-issues.yml to auto assign issues to teams/users set in `.github/CODEOWNERS`